### PR TITLE
add support for extra q3map2 options written by netradiant, for example pakpaths

### DIFF
--- a/warsow.game/default_build_menu.xml
+++ b/warsow.game/default_build_menu.xml
@@ -5,7 +5,7 @@ build commands
 [EnginePath]: path to the engine .. 
 -->
 <project version="2.0">
-<var name="q3map2">&quot;[RadiantPath]q3map2.[ExecutableType]&quot;<cond value="[MonitorAddress]"> -connect [MonitorAddress]</cond> -game qfusion -fs_basepath &quot;[EnginePath]&quot;<cond value="[GameName]"> -fs_game [GameName]</cond></var>
+<var name="q3map2">&quot;[RadiantPath]q3map2.[ExecutableType]&quot; [ExtraQ3map2Args]<cond value="[MonitorAddress]"> -connect [MonitorAddress]</cond> -game qfusion -fs_basepath &quot;[EnginePath]&quot;<cond value="[GameName]"> -fs_game [GameName]</cond></var>
 <build name="Q3Map2: Quick Test Build (very low quality)">
 <command>[q3map2] -meta -minsamplesize 16 -samplesize 32 -maxarea -mv 32000 -mi 32000 -custinfoparms &quot;[MapFile]&quot;</command>
 <command>[q3map2] -vis -saveprt &quot;[MapFile]&quot;</command>


### PR DESCRIPTION
NetRadiant implemented options to add multiple arbitrary paths to directories containing pk3/pk3dir, and options to not look into home dir and engine dir, it helps mapper to get a clean mappig environement the game is not expected to be able to modify. See [xonotic/netradiant!79](https://gitlab.com/xonotic/netradiant/merge_requests/79) for more information.

This PR adds a special keyword to the default build menu so NetRadiant can pass the related options to q3map2 if they are set in NetRadiant.